### PR TITLE
Analytics

### DIFF
--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -135,6 +135,7 @@ export default async function init(el) {
   rows.forEach((row) => { row.classList.add('foreground'); });
 
   if (el.classList.contains('click')) {
+    // push
     const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/analytics.js`);
     await decorateDefaultLinkAnalytics(el);
     const link = el.querySelector('a');

--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -135,7 +135,6 @@ export default async function init(el) {
   rows.forEach((row) => { row.classList.add('foreground'); });
 
   if (el.classList.contains('click')) {
-    // push
     const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/analytics.js`);
     await decorateDefaultLinkAnalytics(el);
     const link = el.querySelector('a');

--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -78,13 +78,14 @@ export default async function init(el) {
   
   const miloLibs = getLibs();
   const { decorateButtons, decorateBlockText } = await import(`${miloLibs}/utils/decorate.js`);
-  const { decorateDefaultLinkAnalytics, createTag } = await import(`${miloLibs}/utils/utils.js`);
+  const { createTag } = await import(`${miloLibs}/utils/utils.js`);
 
   const blockSize = getBlockSize(el);
   decorateButtons(el, `button-${blockTypeSizes[blockSize][3]}`);
   let rows = el.querySelectorAll(':scope > div');
 
   try {
+    const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/analytics.js`);
     await decorateDefaultLinkAnalytics(el);
   } catch (e) {
     console.log('need new libs');

--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -84,13 +84,6 @@ export default async function init(el) {
   decorateButtons(el, `button-${blockTypeSizes[blockSize][3]}`);
   let rows = el.querySelectorAll(':scope > div');
 
-  try {
-    const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/analytics.js`);
-    await decorateDefaultLinkAnalytics(el);
-  } catch (e) {
-    console.log('need new libs');
-  }
-
   if (el.classList.contains('link')) {
     const background = createTag('div', { class: 'background first-background' }, false);
     el.prepend(background);
@@ -142,6 +135,8 @@ export default async function init(el) {
   rows.forEach((row) => { row.classList.add('foreground'); });
 
   if (el.classList.contains('click')) {
+    const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/analytics.js`);
+    await decorateDefaultLinkAnalytics(el);
     const link = el.querySelector('a');
     const foreground = el.querySelector('.foreground');
     if (link && foreground) {


### PR DESCRIPTION
* adjust to analytic functions moved to another file in Milo core

Resolves: [MWPW-135672](https://jira.corp.adobe.com/browse/MWPW-135672)

The see the difference, inspect the foreground in the first pod.  You'll see the daa-ll now equals "Start free trial-1|Generative AI. This " instead of "null"

**Test URLs:**
- Before: https://stage--homepage--adobecom.hlx.live/homepage/index-loggedout
- After: https://analytics--homepage--adobecom.hlx.live/homepage/index-loggedout
