### PR TITLE
Decorate area for fragment LCP and replacePage on personalization

### DIFF
--- a/homepage/scripts/scripts.js
+++ b/homepage/scripts/scripts.js
@@ -142,7 +142,7 @@ const CONFIG = {
 function decorateArea(area = document) {
   (function replaceDotMedia() {
     const resetAttributeBase = (tag, attr) => {
-      document.querySelectorAll(`${tag}[${attr}^="./media_"]`).forEach((el) => {
+      area.querySelectorAll(`${tag}[${attr}^="./media_"]`).forEach((el) => {
         el[attr] = `${new URL(`${CONFIG.contentRoot}${el.getAttribute(attr).substring(1)}`, window.location).href}`;
       });
     };
@@ -151,7 +151,7 @@ function decorateArea(area = document) {
   }());
   
   (function loadLCPImage() {
-    const lcpImg = document.querySelector('img');
+    const lcpImg = area.querySelector('img');
     lcpImg?.setAttribute('loading', 'eager');
     lcpImg?.setAttribute('fetchpriority', 'high');  
   }());

--- a/homepage/scripts/scripts.js
+++ b/homepage/scripts/scripts.js
@@ -152,7 +152,7 @@ function decorateArea(area = document) {
   
   (function loadLCPImage() {
     const lcpImg = document.querySelector('img');
-    lcpImg?.removeAttribute('loading');
+    lcpImg?.setAttribute('loading', 'eager');
     lcpImg?.setAttribute('fetchpriority', 'high');  
   }());
 }

--- a/homepage/scripts/scripts.js
+++ b/homepage/scripts/scripts.js
@@ -125,6 +125,7 @@ const CONFIG = {
   geoRouting: 'on',
   fallbackRouting: 'on',
   locales,
+  decorateArea,
   jarvis: {
     id: 'homepage_loggedout_default',
     version: '1.83',
@@ -138,21 +139,25 @@ const CONFIG = {
  * ------------------------------------------------------------
  */
 
-(function replaceDotMedia() {
-  const resetAttributeBase = (tag, attr) => {
-    document.querySelectorAll(`${tag}[${attr}^="./media_"]`).forEach((el) => {
-      el[attr] = `${new URL(`${CONFIG.contentRoot}${el.getAttribute(attr).substring(1)}`, window.location).href}`;
-    });
-  };
-  resetAttributeBase('img', 'src');
-  resetAttributeBase('source', 'srcset');
-}());
+function decorateArea(area = document) {
+  (function replaceDotMedia() {
+    const resetAttributeBase = (tag, attr) => {
+      document.querySelectorAll(`${tag}[${attr}^="./media_"]`).forEach((el) => {
+        el[attr] = `${new URL(`${CONFIG.contentRoot}${el.getAttribute(attr).substring(1)}`, window.location).href}`;
+      });
+    };
+    resetAttributeBase('img', 'src');
+    resetAttributeBase('source', 'srcset');
+  }());
+  
+  (function loadLCPImage() {
+    const lcpImg = document.querySelector('img');
+    lcpImg?.removeAttribute('loading');
+    lcpImg?.setAttribute('fetchpriority', 'high');  
+  }());
+}
+decorateArea();
 
-(function loadLCPImage() {
-  const lcpImg = document.querySelector('img');
-  lcpImg?.setAttribute('loading', 'eager');
-  lcpImg?.setAttribute('fetchpriority', 'high');  
-}());
 
 const miloLibs = setLibs(LIBS);
 


### PR DESCRIPTION
This will help LCP to be loaded faster and make sure the media path gets updated when the page is replaced by personalization.

Related PR: https://github.com/adobecom/milo/pull/1605

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
- After: https://decorate-area--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
