### PR TITLE
Analytics 2.1 - Switch to attributes.js and send config

### DIFF
--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -77,7 +77,7 @@ export default async function init(el) {
   const linkParentNodeName = linkParentNode.nodeName === 'CHECKOUT-LINK' ? linkParentNode.parentNode.nodeName : linkParentNode.nodeName;
   const miloLibs = getLibs();
   const { decorateButtons, decorateBlockText } = await import(`${miloLibs}/utils/decorate.js`);
-  const { createTag } = await import(`${miloLibs}/utils/utils.js`);
+  const { createTag, getConfig } = await import(`${miloLibs}/utils/utils.js`);
   const blockSize = getBlockSize(el);
 
   decorateButtons(el, `button-${blockTypeSizes[blockSize][3]}`);
@@ -139,8 +139,8 @@ export default async function init(el) {
   rows.forEach((row) => { row.classList.add('foreground'); });
 
   if (el.classList.contains('click')) {
-    const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/analytics.js`);
-    await decorateDefaultLinkAnalytics(el);
+    const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/attributes.js`);
+    await decorateDefaultLinkAnalytics(el, getConfig());
     const link = el.querySelector('a');
     const foreground = el.querySelector('.foreground');
     if (link && foreground) {


### PR DESCRIPTION
The recent analytics update to Milo Core switched from using a file called analytics.js to attributes.js.  Some ad blockers prevent files with the word analytics in the name from being downloaded. analytics.js will be deleted soon, so our reference to the old file needs to be updated.

Config object is also sent in support of the future reverse translation feature.

To test the update, check the sources or network tab.  Before should be downloading libs/martech/analytics.js but the after link should be downloading libs/martech/attributes.js

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/drafts/vgoodrich/fragments/analytics/?martech=off
- After: https://martech21--homepage--adobecom.hlx.page/homepage/drafts/vgoodrich/fragments/analytics/?martech=off
