### PR TITLE
Switch from analytics.js to attributes.js

### DIFF
--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -139,7 +139,7 @@ export default async function init(el) {
   rows.forEach((row) => { row.classList.add('foreground'); });
 
   if (el.classList.contains('click')) {
-    const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/analytics.js`);
+    const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/attributes.js`);
     await decorateDefaultLinkAnalytics(el);
     const link = el.querySelector('a');
     const foreground = el.querySelector('.foreground');


### PR DESCRIPTION
Some ad blockers prevent files with "analytics" in the name from being used. A previous PR in Milo core moved the needed function to attributes.js but an upcoming PR deletes the analytics.js file.  So we must switch our reference before that happens

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?milolibs=mwpw-136617-analytics-en
- After: https://remove-analytics-js--homepage--adobecom.hlx.live/homepage/index-loggedout?milolibs=mwpw-136617-analytics-en
- Short term after (after this PR but before the Milo PR): https://remove-analytics-js--homepage--adobecom.hlx.live/homepage/index-loggedout
