### PR TITLE
Homepage brick updates to support upcoming designs

### DIFF
--- a/homepage/blocks/homepage-brick/homepage-brick.css
+++ b/homepage/blocks/homepage-brick/homepage-brick.css
@@ -157,7 +157,7 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   padding: 0;
 }
 
-.homepage-brick .foreground,
+.homepage-brick:not(.above-pods) .foreground,
 .homepage-brick.link.split-background .foreground > div,
 .homepage-brick.news > div {
   padding: var(--spacing-s);
@@ -249,7 +249,8 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   display: flex;
   gap: var(--spacing-s);
   flex-wrap: wrap;
-  align-items: center;
+  align-items: flex-start;
+  flex-direction: column;
 }
 
 .homepage-brick.link .foreground > div {
@@ -423,6 +424,11 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
 @media screen and (min-width: 600px) {
   .masonry .homepage-brick {
     min-height: 500px;
+  }
+
+  .homepage-brick .action-area {
+    align-items: center;
+    flex-direction: row;
   }
 }
 

--- a/homepage/blocks/homepage-brick/homepage-brick.css
+++ b/homepage/blocks/homepage-brick/homepage-brick.css
@@ -43,7 +43,7 @@
 .section.masonry:not([class*="border-radius"]) > div > div.fragment > div.section > div,
 .section.masonry:not([class*="border-radius"]) > div .background,
 .section.masonry:not([class*="border-radius"]) > div > div.fragment > div.section > div .background {
-  border-radius: 16px;
+  border-radius: 20px;
 }
 
 
@@ -276,7 +276,7 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   color: inherit;
 }
 
-.homepage-brick:not(.click) a,
+.homepage-brick a:not(.con-button),
 .homepage-brick.click div.click-link {
   color: inherit;
   font-weight: 700;

--- a/homepage/blocks/homepage-brick/homepage-brick.css
+++ b/homepage/blocks/homepage-brick/homepage-brick.css
@@ -182,7 +182,7 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   background-color: #ededed;
 }
 
-.homepage-brick.click.semi-transparent .first-background {
+.homepage-brick.semi-transparent .first-background {
   background: linear-gradient(130deg, rgba(255,255,255,0.6), transparent);
   border: solid 2px #fff;
 }

--- a/homepage/blocks/homepage-brick/homepage-brick.css
+++ b/homepage/blocks/homepage-brick/homepage-brick.css
@@ -276,14 +276,35 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   color: inherit;
 }
 
-.homepage-brick:not(.multi-link) a:not([class*="button"]),
+.homepage-brick:not(.click) a:not([class*="button"]),
 .homepage-brick.click div.click-link {
   color: inherit;
   font-weight: 700;
 }
 
-.homepage-brick.multi-link a:not([class*="button"]) {
+.homepage-brick a:not([class*="button"]) {
+  text-decoration: none;
+}
+
+.homepage-brick a:not([class*="button"]):hover {
   text-decoration: underline;
+}
+
+.homepage-brick.links-m.multi-link a:not([class*="button"]) {
+  text-decoration: underline;
+  font-weight: 500;
+}
+
+.homepage-brick [class^="detail"].icon-detail {
+    margin-top: var(--spacing-xs) !important;
+}
+
+.homepage-brick [class^="detail"].icon-detail picture img {
+    height: 35px;
+    width: 35px;
+    vertical-align: middle;
+    margin-right: var(--spacing-xxs);
+    margin-top: -5px !important;
 }
 
 .static-links a.foreground,

--- a/homepage/blocks/homepage-brick/homepage-brick.css
+++ b/homepage/blocks/homepage-brick/homepage-brick.css
@@ -277,23 +277,18 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   color: inherit;
 }
 
-.homepage-brick:not(.click) a:not([class*="button"]),
+.homepage-brick:not(.click):not(.static-links) a:not([class*="button"]),
 .homepage-brick.click div.click-link {
   color: inherit;
   font-weight: 700;
 }
 
-.homepage-brick a:not([class*="button"]) {
+.homepage-brick:not(.static-links) a:not([class*="button"]) {
   text-decoration: none;
 }
 
 .homepage-brick a:not([class*="button"]):hover {
   text-decoration: underline;
-}
-
-.homepage-brick.links-m.multi-link a:not([class*="button"]) {
-  text-decoration: underline;
-  font-weight: 500;
 }
 
 .homepage-brick [class^="detail"].icon-detail {

--- a/homepage/blocks/homepage-brick/homepage-brick.css
+++ b/homepage/blocks/homepage-brick/homepage-brick.css
@@ -276,10 +276,14 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   color: inherit;
 }
 
-.homepage-brick:not(.multi-link) a:not(.con-button),
+.homepage-brick:not(.multi-link) a:not([class*="button"]),
 .homepage-brick.click div.click-link {
   color: inherit;
   font-weight: 700;
+}
+
+.homepage-brick.multi-link a:not([class*="button"]) {
+  text-decoration: underline;
 }
 
 .static-links a.foreground,

--- a/homepage/blocks/homepage-brick/homepage-brick.css
+++ b/homepage/blocks/homepage-brick/homepage-brick.css
@@ -276,7 +276,7 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   color: inherit;
 }
 
-.homepage-brick a:not(.con-button),
+.homepage-brick:not(.multi-link) a:not(.con-button),
 .homepage-brick.click div.click-link {
   color: inherit;
   font-weight: 700;

--- a/homepage/blocks/homepage-brick/homepage-brick.css
+++ b/homepage/blocks/homepage-brick/homepage-brick.css
@@ -154,6 +154,13 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
 .homepage-brick {
   position: relative;
   text-size-adjust: none;
+  padding: 0;
+}
+
+.homepage-brick .foreground,
+.homepage-brick.link.split-background .foreground > div,
+.homepage-brick.news > div {
+  padding: var(--spacing-s);
 }
 
 .masonry .homepage-brick {
@@ -269,9 +276,8 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   color: inherit;
 }
 
-.homepage-brick.news a,
-.homepage-brick.click div.click-link,
-.homepage-brick.link a:not(.con-button) {
+.homepage-brick:not(.click) a,
+.homepage-brick.click div.click-link {
   color: inherit;
   font-weight: 700;
 }
@@ -289,12 +295,6 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
 .homepage-brick.click .foreground p.detail-m:first-child {
   font-size: var(--type-detail-l-size);
   line-height: var(--type-detail-l-lh);
-}
-
-.homepage-brick,
-.homepage-brick.link.split-background  .foreground > div,
-.homepage-brick.news > div {
-  padding: var(--spacing-s);
 }
 
 .homepage-brick.above-pods {

--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -144,7 +144,7 @@ export default async function init(el) {
   rows.forEach((row) => { row.classList.add('foreground'); });
 
   if (el.classList.contains('click')) {
-    const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/analytics.js`);
+    const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/attributes.js`);
     await decorateDefaultLinkAnalytics(el);
     const link = el.querySelector('a');
     const foreground = el.querySelector('.foreground');

--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -121,7 +121,7 @@ export default async function init(el) {
         el.classList.add('click');
       } else {
         el.classList.add('multi-link');
-        links.forEach((a) => a.parentNode.classList.add('body-xs'));
+        links.forEach((a) => a.parentNode.className = 'action-area body-s');
       }
     }
   }

--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -121,7 +121,7 @@ export default async function init(el) {
         el.classList.add('click');
       } else {
         el.classList.add('multi-link');
-        const actionAreaSize = el.classList.contains('links-m') ? 'body-m': 'body-xs';
+        const actionAreaSize = el.classList.contains('static-links') ? 'body-m': 'body-xs';
         links.forEach((a) => a.parentNode.className = `action-area ${actionAreaSize}`);
         if (el.classList.contains('icon-in-header')) {
           const header = el.querySelector('h1, h2, h3, h4, h5, h6');

--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -121,7 +121,15 @@ export default async function init(el) {
         el.classList.add('click');
       } else {
         el.classList.add('multi-link');
-        links.forEach((a) => a.parentNode.className = 'action-area body-m');
+        const actionAreaSize = el.classList.contains('links-m') ? 'body-m': 'body-xs';
+        links.forEach((a) => a.parentNode.className = `action-area ${actionAreaSize}`);
+        if (el.classList.contains('icon-in-header')) {
+          const header = el.querySelector('h1, h2, h3, h4, h5, h6');
+          const icon = el.querySelector('picture');
+          if (header && icon) {
+            header.prepend(icon);
+          }
+        }
       }
     }
   }
@@ -173,5 +181,11 @@ export default async function init(el) {
       link.append(...foreground.childNodes);
       foreground.remove();
     }
+  }
+
+  const detail = el.querySelector('p[class*="detail"]');
+  if (detail) {
+    const icon = detail.querySelector('img');
+    if (icon) detail.classList.add('icon-detail');
   }
 }

--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -121,7 +121,7 @@ export default async function init(el) {
         el.classList.add('click');
       } else {
         el.classList.add('multi-link');
-        links.forEach((a) => a.parentNode.className = 'action-area body-s');
+        links.forEach((a) => a.parentNode.className = 'action-area body-m');
       }
     }
   }

--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -106,9 +106,8 @@ export default async function init(el) {
     headers.forEach((header) => enforceHeaderLevel(header, 1));
     el.querySelectorAll('a.con-button').forEach((button) => button.classList.add('button-justified-mobile'));
   } else {
-    el.classList.add('click');
-    let [head, ...tail] = rows;
     if (rows.length > 1) {
+      let [head, ...tail] = rows;
       decorateBlockBg(head);
       head.classList.add('first-background');
       rows = tail;
@@ -116,6 +115,12 @@ export default async function init(el) {
         [head, ...tail] = rows;
         decorateBlockBg(head);
         rows = tail;
+      }
+      const links = el.querySelectorAll('a');
+      if (links.length === 1) {
+        el.classList.add('click');
+      } else {
+        links.forEach((a) => a.parentNode.className = 'body-xs');
       }
     }
   }

--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -120,7 +120,8 @@ export default async function init(el) {
       if (links.length === 1) {
         el.classList.add('click');
       } else {
-        links.forEach((a) => a.parentNode.className = 'body-xs');
+        el.classList.add('multi-link');
+        links.forEach((a) => a.parentNode.classList.add('body-xs'));
       }
     }
   }


### PR DESCRIPTION
This ticket adds support for the following XD's: 
- https://xd.adobe.com/view/21d87140-6d36-4e14-a738-b44c34a614a7-748b/ - side by side text links, text links are larger than current
- https://xd.adobe.com/view/2b016cd8-4218-4706-b64c-0e447cbe722f-7e52/ - side by side button links + icon in eyebrow
- https://xd.adobe.com/view/ce561bf1-4433-4c29-8018-b41111b70264-9b05/ - stacked links both button and text links, text links are same size as current

Resolves: [MWPW-139931](https://jira.corp.adobe.com/browse/MWPW-139931)

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/drafts/chrlin/mashup-examples?martech=off
- After: https://multi-link--homepage--adobecom.hlx.page/homepage/drafts/chrlin/mashup-examples?martech=off
