### PR TITLE
MWPW-142399

### DIFF
--- a/homepage/blocks/homepage-brick/homepage-brick.css
+++ b/homepage/blocks/homepage-brick/homepage-brick.css
@@ -451,3 +451,9 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
 }
 
 .homepage-brick.right .action-area { justify-content: end; }
+
+/* Temp Modal Fix */
+.dialog-modal.commerce-frame .fragment,
+.dialog-modal.commerce-frame .section {
+  height: 100vh;
+}


### PR DESCRIPTION
Twp Modal not displaying in tablet viewports or smaller on Safari.
This is a relatively well know limitation of Safari, we should use `100vh` instead of `100%` 

Resolves: [MWPW-142399](https://jira.corp.adobe.com/browse/MWPW-142399)

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off#mini-plans-web-cta-photoshop-card
- After: https://mwpw-142399--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off#mini-plans-web-cta-photoshop-card
