### PR TITLE
Adding chimeraOrigin to homepage repo (milo consumer)

### DIFF
--- a/homepage/scripts/scripts.js
+++ b/homepage/scripts/scripts.js
@@ -120,6 +120,7 @@ const locales = {
 
 // Add any config options.
 const CONFIG = {
+  chimeraOrigin: 'homepage',
   codeRoot: '/homepage',
   contentRoot: '/homepage',
   imsClientId: 'homepage_milo',


### PR DESCRIPTION
<!-- Before submitting, please review all open PRs. -->
This is needed for CaaS marquees to run queries against the `homepage` content.

Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
- After: https://<branch>--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
