### PR TITLE
Update cookie with domain '.adobe.com'

### DIFF
--- a/homepage/scripts/scripts.js
+++ b/homepage/scripts/scripts.js
@@ -226,11 +226,11 @@ function loadStyles() {
     if (isSignedInUser && !signedInCookie) {
       const date = new Date();
       date.setTime(date.getTime() + (365*24*60*60*1000));
-      document.cookie = ACOM_SIGNED_IN_STATUS + '=1;path=/;expires='+ date.toUTCString() + ';';
+      document.cookie = ACOM_SIGNED_IN_STATUS + '=1;path=/;expires='+ date.toUTCString() + ';domain=.adobe.com;';
       window.location.reload();
     }
     if (!isSignedInUser && signedInCookie) {
-      document.cookie = ACOM_SIGNED_IN_STATUS + '=;path=/;expires=' + new Date(0).toUTCString() + ';';
+      document.cookie = ACOM_SIGNED_IN_STATUS + '=;path=/;expires=' + new Date(0).toUTCString() + ';domain=.adobe.com;';
       window.location.reload();
     }
   })


### PR DESCRIPTION
Resolves: [MWPW-142701](https://jira.corp.adobe.com/browse/MWPW-142701)

**Test URLs:**
- Before: https://stage--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
- After: https://cookie-update--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off

QA note:
I've tested with 'test' cookie in Chrome console at adobe.com, and it seems adding cookie as expected with domain `.adobe.com`