### PR TITLE
Flicker fix

### DIFF
--- a/homepage/scripts/scripts.js
+++ b/homepage/scripts/scripts.js
@@ -228,7 +228,7 @@ function loadStyles() {
       const date = new Date();
       date.setTime(date.getTime() + (365*24*60*60*1000));
       document.cookie = `${ACOM_SIGNED_IN_STATUS}=1;path=/;expires=${date.toUTCString()};domain=${isStage ? 'www.stage.' : ''}adobe.com;`;
-      window.location.replace('');
+      window.location.replace(`/home${window.location.search}`);
     }
     if (!isSignedInUser && signedInCookie) {
       document.cookie = `${ACOM_SIGNED_IN_STATUS}=;path=/;expires=${new Date(0).toUTCString()};`;

--- a/homepage/scripts/scripts.js
+++ b/homepage/scripts/scripts.js
@@ -233,7 +233,7 @@ function loadStyles() {
     if (!isSignedInUser && signedInCookie) {
       document.cookie = `${ACOM_SIGNED_IN_STATUS}=;path=/;expires=${new Date(0).toUTCString()};`;
       document.cookie = `${ACOM_SIGNED_IN_STATUS}=;path=/;expires=${new Date(0).toUTCString()};domain=${isStage ? 'www.stage.' : ''}adobe.com;`;
-      window.location.replace('');
+      window.location.replace(window.location.search);
     }
   })
   await loadAreaPromise;


### PR DESCRIPTION
Follow up from #66 

Looks like the window.location.replace(''); from flicker fix code doesn't invalidate the browser cache unlike localhost test.
This should work like reload()

Test URLs:

Before: https://stage--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
After: https://flicker-fix--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off