### PR TITLE
MWPW-143459: Adding send to caas button to homepage sidekick

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -80,7 +80,7 @@
       "containerId": "tools",
       "title": "Send to CaaS",
       "id": "sendtocaas",
-      "environments": ["live", "prod"],
+      "environments": ["dev","preview", "live", "prod"],
       "event": "send-to-caas",
       "excludePaths": ["https://milo.adobe.com/tools/caas**", "*.json"]
     },

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -80,7 +80,7 @@
       "containerId": "tools",
       "title": "Send to CaaS",
       "id": "sendtocaas",
-      "environments": ["dev","preview", "live", "prod"],
+      "environments": ["live", "prod"],
       "event": "send-to-caas",
       "excludePaths": ["https://milo.adobe.com/tools/caas**", "*.json"]
     },

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -78,6 +78,14 @@
     },
     {
       "containerId": "tools",
+      "title": "Send to CaaS",
+      "id": "sendtocaas",
+      "environments": ["dev","preview", "live", "prod"],
+      "event": "send-to-caas",
+      "excludePaths": ["https://milo.adobe.com/tools/caas**", "*.json"]
+    },
+    {
+      "containerId": "tools",
       "id": "locales",
       "title": "Locales",
       "environments": [


### PR DESCRIPTION
Send to CaaS Button missing on homepage sidekick.

![image](https://github.com/adobecom/homepage/assets/10876964/cf08825a-2da6-4853-bf8c-40621cd4a581)

This is because it wasn't added to `config.json` like other consumers (e.g. bacom)

```
https://github.com/adobecom/bacom/blob/main/tools/sidekick/config.json#L50
```

Jira Ticket: https://jira.corp.adobe.com/browse/MWPW-143459
