### PR TITLE
MWPW-143891: ignore isSignedInUser && signedInCookie in fragments

### DIFF
--- a/homepage/scripts/scripts.js
+++ b/homepage/scripts/scripts.js
@@ -238,7 +238,7 @@ function loadStyles() {
       }
       window.location.reload();
     }
-    if (signedInCookie && isSignedInUser) {
+    if (signedInCookie && isSignedInUser && !window.location.href.includes('/fragments/')) {  
       window.location.reload();
     }
   })


### PR DESCRIPTION
Ignore isSignedInUser && signedInCookie in fragments in order to allow SendToCaas to be executed

Resolves: [MWPW-143891](https://jira.corp.adobe.com/browse/MWPW-143891)

**Test URLs:**
- Before: https://www.adobe.com/homepage/fragments/loggedout/tests/2024/q2/ace0860/dc?martech=off
- After: https://MWPW-143891--homepage--adobecom.hlx.live/homepage/fragments/loggedout/tests/2024/q2/ace0860/dc?martech=off
