### PR TITLE
cheat css to avoid Milo to override Homepage

### DIFF
--- a/head.html
+++ b/head.html
@@ -5,7 +5,7 @@
 <style>body { display: none; }</style>
 <link rel="icon" href="data:,">
 <style id="ims-body-style">
-  body {
+  body:first-of-type {
       opacity: 0.01 !important;
   }
 </style>


### PR DESCRIPTION
This PR avoids the following style for overriding the body opacity that is used to combat flicker.
https://github.com/adobecom/milo/blob/stage/libs/styles/styles.css#L669

Resolves: [CCH-22855](https://jira.corp.adobe.com/browse/CCH-22855)
