### PR TITLE
MWPW-146726 [HOMEPAGE] Homepage brick removes line breaks from headers

### DIFF
--- a/homepage/blocks/homepage-brick/homepage-brick.js
+++ b/homepage/blocks/homepage-brick/homepage-brick.js
@@ -62,7 +62,7 @@ function enforceHeaderLevel(node, level) {
   for (const attr of node.attributes) {
     clone.setAttribute(attr.name, attr.value);
   }
-  clone.innerText = node.innerText;
+  clone.innerHTML = node.innerHTML;
   node.replaceWith(clone);
 }
 


### PR DESCRIPTION
Detailed Description: Homepage brick removes line breaks from headers
................................
Steps to Reproduce:
1. In a page with the homepage-brick block, add a line break (shift+enter) to the header
2. Preview the page

Expected Results: Line break should be present on page.
................................
Actual Results: Line break is missing.

Resolves: [MWPW-146726](https://jira.corp.adobe.com/browse/MWPW-146726)

**Test URLs:**
- Before: https://preserveheaderhtml--homepage--adobecom.hlx.page/homepage/drafts/jacquim/requested-sandbox?martech=off
- After: https://preserveheaderhtml--homepage--adobecom.hlx.page/homepage/drafts/jacquim/requested-sandbox?martech=off
