### PR TITLE
MWPW-146847: Add project and host to sidekick config

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,4 +1,6 @@
 {
+  "project": "HOMEPAGE",
+  "host": "www.adobe.com",
   "plugins": [
     {
       "id": "library",


### PR DESCRIPTION
Floodgate actions are dependent on the project and host data sent from the sidekick to perform some actions (similar to how it is setup in dc, cc, bacom etc.). This was missing in the homepage sidekick setup. Updated config.json with this additional info.

Resolves: [MWPW-146847](https://jira.corp.adobe.com/browse/MWPW-146847)