### PR TITLE
MWPW-153744: Stage URL to point to Stage libs instead of Prod.

### DIFF
--- a/homepage/scripts/utils.js
+++ b/homepage/scripts/utils.js
@@ -24,6 +24,10 @@ export const [setLibs, getLibs] = (() => {
         }
         if (!['.hlx.', 'local'].some((i) => hostname.includes(i))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
+        // Validate the branch name to mitigate potential security risks
+        if (!/^[a-zA-Z0-9-_]+$/.test(branch)) {
+          throw new Error("Invalid branch name.");
+        }
         if (branch === 'local') return 'http://localhost:6456/libs';
         return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;
       })();

--- a/homepage/scripts/utils.js
+++ b/homepage/scripts/utils.js
@@ -19,7 +19,10 @@ export const [setLibs, getLibs] = (() => {
     (prodLibs, location) => {
       libs = (() => {
         const { hostname, search } = location || window.location;
-        if (!['.hlx.', '.stage.', 'local'].some((i) => hostname.includes(i))) return prodLibs;
+        if (hostname.includes('stage.adobe.com')) {
+          return "https://stage--milo--adobecom.hlx.live/libs";
+        }
+        if (!['.hlx.', 'local'].some((i) => hostname.includes(i))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
         if (branch === 'local') return 'http://localhost:6456/libs';
         return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;


### PR DESCRIPTION
- Fixes the inconsistency of pointing to Milo prod libs even when the url is stage.adobe.com
- Fixes potential vulnerability of accepting special characters in branch name.

Resolves: [MWPW-153744](https://jira.corp.adobe.com/browse/MWPW-153744)

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
- After: https://stage--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
