### PR TITLE
MWPW-158064 [MEP] Homepage Linkpod for MAX

### DIFF
--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
@@ -1,0 +1,453 @@
+/* marquee temp support. */
+.marquee.mobile-high-contrast,
+.marquee.high-contrast {
+  color: #000;
+}
+
+@media screen and (min-width: 600px) {
+  .marquee.tablet-high-contrast {
+    color: #000;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .marquee.desktop-high-contrast {
+    color: #000;
+  }
+}
+
+/* masonry support */
+
+/* border radius */
+.section.border-radius-s > div,
+.section.border-radius-s > div .background,
+.section.border-radius-s > .homepage-brick.click a {
+  border-radius: 4px;
+}
+
+.section.border-radius-l > div,
+.section.border-radius-l > div .background,
+.section.border-radius-l > .homepage-brick.click a {
+  border-radius: 16px;
+}
+
+.section.no-border-radius > div,
+.section.no-border-radius > div .background {
+  border-radius: 0;
+  padding: var(--spacing-l) 0;
+}
+
+
+.section.masonry:not([class*="border-radius"]) > div,
+.section.masonry:not([class*="border-radius"]) .homepage-brick.click a,
+.section.masonry:not([class*="border-radius"]) > div > div.fragment > div.section > div,
+.section.masonry:not([class*="border-radius"]) > div .background,
+.section.masonry:not([class*="border-radius"]) > div > div.fragment > div.section > div .background {
+  border-radius: 20px;
+}
+
+
+.section[class*='-up'] {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(276px, 1fr));
+  gap: var(--spacing-m);
+  align-items: start;
+  padding-left: var(--grid-margins-width);
+  padding-right: var(--grid-margins-width);
+}
+
+/* defaults */
+.section.masonry {
+  grid-template-columns: repeat(1, 1fr);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.section.masonry > div:not([class]),
+.section.masonry > div:not([class]) > div.fragment,
+.section.masonry > div:not([class]) > div.fragment > div.section {
+  display: grid;
+}
+
+.section.masonry:not([class*="spacing"]) {
+  align-items: stretch;
+  padding: var(--spacing-m) var(--spacing-xl);
+}
+
+.section.masonry:not([class*="spacing"]):not([style]) {
+  max-width: 1920px;
+}
+
+.section.masonry.small-top-padding:not([class*="spacing"]) {
+  padding-top: var(--spacing-s);
+}
+
+.homepage-brick.above-pods .foreground {
+  padding-top: var(--spacing-xs);
+}
+
+@media screen and (max-width: 599px) {
+  .homepage-brick.above-pods .foreground > div {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .homepage-brick.above-pods .foreground > div .body-m {
+      order: 3;
+  }
+
+  .homepage-brick.above-pods .foreground > div .action-area {
+    order: 2;
+    margin-bottom: var(--spacing-s);
+    display: flex;
+    gap: var(--spacing-s);
+    flex-flow: column wrap;
+    align-items: stretch;
+  }
+}
+
+@media screen and (min-width: 600px) and (max-width: 1199px) {
+  .section.masonry {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .section.masonry .full-grid {
+    grid-column: span 2;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .section.masonry {
+    grid-template-columns: repeat(12, 1fr);
+  }
+
+  .section.masonry > div { grid-column: span 4; }
+  .section.masonry .half-grid { grid-column: span 6; }
+  .section.masonry .two-thirds-grid { grid-column: span 8; }
+  .section.masonry [class*="full-grid"] {grid-column: span 12; }
+
+  .section.masonry .homepage-brick.click[class*="full-grid"] {
+    padding-top: var(--spacing-xl-static);
+    text-align: center;
+  }
+
+  .section.masonry .homepage-brick.click.left-align-desktop[class*="full-grid"] {
+    text-align: left;
+  }
+
+  .section.masonry .homepage-brick.click.right-align-desktop[class*="full-grid"] {
+    text-align: right;
+  }
+
+  .homepage-brick.above-pods .foreground {
+    max-width: 1000px;
+    margin: 0 auto;
+    padding-top: var(--spacing-m);
+  }
+}
+
+body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id] {
+  display: none;
+}
+
+/* block CSS */
+.homepage-brick {
+  position: relative;
+  text-size-adjust: none;
+  padding: 0;
+}
+
+.homepage-brick:not(.above-pods) .foreground,
+.homepage-brick.link.split-background .foreground > div,
+.homepage-brick.news > div {
+  padding: var(--spacing-s);
+}
+
+.masonry .homepage-brick {
+  min-height: 450px;
+}
+
+.homepage-brick .background {
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+  overflow: hidden;
+}
+
+.homepage-brick .first-background,
+.homepage-brick.split-background .foreground > :nth-child(2),
+.homepage-brick.news {
+  background-color: #ededed;
+}
+
+.homepage-brick.semi-transparent .first-background {
+  background: linear-gradient(130deg, rgba(255,255,255,0.6), transparent);
+  border: solid 2px #fff;
+}
+
+.homepage-brick .background > div {
+  height: 100%;
+}
+
+.homepage-brick .background img {
+  object-fit: cover;
+  width: 100%;
+  height: 100%;
+}
+
+.homepage-brick .background img[style] {
+  object-fit: contain;
+}
+
+.homepage-brick p,
+.homepage-brick [class^="body-"] { margin: var(--spacing-xxs) 0; }
+
+.homepage-brick [class^="heading"] { margin: 0 0 var(--spacing-xxs) 0; }
+.homepage-brick.link [class^="heading"]:not(:first-child) { margin-top: var(--spacing-xs); }
+
+.homepage-brick.news [class^="heading"] {
+  margin-bottom: 0;
+}
+
+.homepage-brick.heading-xs p.body-m {
+  font-size: var(--type-body-s-size);
+  line-height: var(--type-body-s-lh);
+  margin: 4px 0;
+}
+
+.text.mashup .foreground .body-m:nth-child(3) {
+  font-size: var(--type-body-s-size);
+  line-height: var(--type-body-s-lh);
+}
+
+.homepage-brick [class^="detail"] { margin: 0 0 var(--spacing-xs) 0; }
+.homepage-brick p.action-area { margin-top: var(--spacing-s); }
+.homepage-brick.click p.action-area { margin-top: 0; }
+.homepage-brick div > *:last-child { margin-bottom: 0; }
+.grid .homepage-brick div > *:last-child { margin-bottom: var(--spacing-s); }
+.homepage-brick .foreground > div *:first-child { margin-top: 0; }
+
+.homepage-brick .foreground {
+  margin: 0 auto;
+  position: relative;
+  z-index: 2;
+}
+
+.homepage-brick:not(.above-pods) .foreground {
+  max-width: var(--grid-container-width);
+}
+
+[class*='-up'] .homepage-brick .foreground {
+  max-width: none;
+  margin: 0;
+}
+
+.homepage-brick .action-area {
+  margin-top: var(--spacing-s);
+  display: flex;
+  gap: var(--spacing-s);
+  flex-wrap: wrap;
+  align-items: flex-start;
+  flex-direction: column;
+}
+
+.homepage-brick.link .foreground > div {
+  padding: var(--spacing-s) var(--spacing-s) 0 var(--spacing-s);
+}
+
+.homepage-brick.link:not(.split-background) .foreground > div {
+  padding-bottom: 0;
+}
+
+.homepage-brick.link:not(.split-background) .foreground:last-child > div {
+  padding-top: var(--spacing-xs);
+  /* padding-bottom: var(--spacing-s); */
+}
+
+.homepage-brick.dark,
+.homepage-brick.split-background .foreground > div:first-child {
+  color: #FFF;
+}
+
+.homepage-brick a,
+.homepage-brick.click div.click-link,
+.homepage-brick.link a:not(.con-button) {
+  color: inherit;
+}
+
+.homepage-brick:not(.click):not(.static-links) a:not([class*="button"]),
+.homepage-brick.click div.click-link {
+  color: inherit;
+  font-weight: 700;
+}
+
+.homepage-brick:not(.static-links) a:not([class*="button"]) {
+  text-decoration: none;
+}
+
+.homepage-brick a:not([class*="button"]):hover {
+  text-decoration: underline;
+}
+
+.homepage-brick [class^="detail"].icon-detail {
+    margin-top: var(--spacing-xs) !important;
+}
+
+.homepage-brick [class^="detail"].icon-detail picture img {
+    height: 35px;
+    width: 35px;
+    vertical-align: middle;
+    margin-right: var(--spacing-xxs);
+    margin-top: -5px !important;
+}
+
+.static-links a.foreground,
+.section.static-links .homepage-brick.click a:not([class*="button"]),
+.homepage-brick.click a:hover {
+  text-decoration: none;
+}
+
+.homepage-brick.click:hover div.click-link {
+  text-decoration: underline;
+}
+
+.homepage-brick.click .foreground p.detail-m:first-child {
+  font-size: var(--type-detail-l-size);
+  line-height: var(--type-detail-l-lh);
+}
+
+.homepage-brick.above-pods {
+  padding: var(--spacing-l);
+}
+
+.homepage-brick.click {
+  padding: 0;
+  display: flex;
+  cursor: pointer;
+}
+
+.homepage-brick.click > .foreground {
+  padding: var(--spacing-m) var(--spacing-s) var(--spacing-s);
+  flex-grow: 1;
+}
+
+.homepage-brick.link,
+.homepage-brick.link .foreground {
+  padding: 0;
+}
+
+.section:not(.no-border-radius) .homepage-brick .highlight-row,
+.section:not(.no-border-radius) .homepage-brick.homepage-brick.split-background .foreground > :first-child {
+  border-radius: 16px 16px 0 0;
+}
+
+.section.border-radius-s .homepage-brick:not(.click) .foreground > div:first-child {
+  border-radius: 4px 4px 0 0;
+}
+
+.section:not(.no-border-radius) .homepage-brick.link.split-background .foreground > div:last-child {
+    border-radius: 0 0 16px 16px;
+}
+
+.homepage-brick.news,
+.homepage-brick.link:not(.split-background) {
+  padding: 0 !important;
+}
+
+.homepage-brick.link:not(.split-background) > :first-child {
+  padding: var(--spacing-xs);
+}
+
+.homepage-brick.link .highlight-row,
+.homepage-brick.link.split-background > .foreground > :first-child {
+  color: #FFF;
+  background: linear-gradient(125deg, rgba(237, 5, 41, 1) 0%, rgba(155, 0, 193, 1) 50%, rgba(91, 0, 198, 1) 100%) ;
+  font-weight: 700;
+  padding: var(--spacing-m) var(--spacing-s) var(--spacing-s);
+}
+
+.homepage-brick.news hr {
+  margin: var(--spacing-xs) 0;
+}
+
+.homepage-brick.news .highlight-row {
+  color: #FFF;
+  background: linear-gradient(90deg, rgba(33,99,212,1) 0%, rgba(93,227,116,1) 100%);
+}
+
+.homepage-brick .positioned-background {
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+
+.homepage-brick .positioned-background picture {
+  display: none;
+}
+
+.homepage-brick .mobileOnly,
+.homepage-brick .tabletOnly,
+.homepage-brick .desktopOnly {
+  display: none;
+}
+
+/* mashup */
+.homepage-brick.click:hover .con-button:not(.blue):not(.fill) {
+    background-color: var(--color-black);
+    border-color: var(--color-black);
+    color: var(--color-white);
+    text-decoration: none;
+}
+
+@media screen and (max-width: 1023px) {
+  .section.masonry:not([class*="spacing"]) {
+    padding: var(--spacing-s) var(--spacing-s);
+  }
+
+  .homepage-brick .mobileOnly {
+    display: block;
+  }
+}
+
+@media screen and (min-width: 600px) and (max-width: 1199px) {
+  .homepage-brick .tabletOnly {
+    display: block;
+  }
+}
+
+@media screen and (min-width: 600px) {
+  .masonry .homepage-brick {
+    min-height: 500px;
+  }
+
+  .homepage-brick .action-area {
+    align-items: center;
+    flex-direction: row;
+  }
+}
+
+@media screen and (min-width: 1200px) {
+  .homepage-brick .desktopOnly {
+    display: block;
+  }
+
+  /* mashup */
+  .homepage-brick.above-pods { text-align: center; }
+  .homepage-brick.above-pods .action-area { justify-content: center; }
+}
+
+/* Alignment */
+.homepage-brick.center {
+  text-align: center;
+  align-items: center;
+}
+
+.homepage-brick.center .action-area { justify-content: center; }
+
+.homepage-brick.right {
+  text-align: right;
+  align-items: end;
+}
+
+.homepage-brick.right .action-area { justify-content: end; }

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
@@ -367,17 +367,17 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   font-weight: 700;
   padding: var(--spacing-m) var(--spacing-s) var(--spacing-s);
 }
-.max-override.homepage-brick.link.split-background>.foreground> :first-child {
+.homepage-brick.link.split-background>.foreground> :first-child {
   background: url('/homepage/assets/maxlinkpod-images/media_1d1d79f99a64f4a6e066253565ebf07c8a0f6bf07.jpeg') no-repeat center center / cover;
 }
 
 @media screen and (min-width: 600px) {
-  .max-override.homepage-brick.link.split-background>.foreground> :first-child {
+  .homepage-brick.link.split-background>.foreground> :first-child {
     background: url('/homepage/assets/maxlinkpod-images/media_12290414600700935f22f3592af86e6daeb13dc10.jpeg') no-repeat center center / cover;
   }
 }
 @media screen and (min-width: 1200px) {
-  .max-override.homepage-brick.link.split-background>.foreground> :first-child {
+  .homepage-brick.link.split-background>.foreground> :first-child {
     background: url('/homepage/assets/maxlinkpod-images/media_18ae9f841e7d0785e5080f0dd2bc7b27702320799.jpeg') no-repeat center center / cover;
   }
 }

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
@@ -378,7 +378,7 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
 }
 @media screen and (min-width: 1200px) {
   .max-override.homepage-brick.link.split-background>.foreground> :first-child {
-    background: url('homepage/assets/maxlinkpod-images/media_18ae9f841e7d0785e5080f0dd2bc7b27702320799.jpeg') no-repeat center center / cover;
+    background: url('/homepage/assets/maxlinkpod-images/media_18ae9f841e7d0785e5080f0dd2bc7b27702320799.jpeg') no-repeat center center / cover;
   }
 }
 

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
@@ -367,6 +367,20 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   font-weight: 700;
   padding: var(--spacing-m) var(--spacing-s) var(--spacing-s);
 }
+.max-override.homepage-brick.link.split-background>.foreground> :first-child {
+  background: url('/homepage/assets/maxlinkpod-images/media_1d1d79f99a64f4a6e066253565ebf07c8a0f6bf07.jpeg') no-repeat center center / cover;
+}
+
+@media screen and (min-width: 600px) {
+  .max-override.homepage-brick.link.split-background>.foreground> :first-child {
+    background: url('/homepage/assets/maxlinkpod-images/media_12290414600700935f22f3592af86e6daeb13dc10.jpeg') no-repeat center center / cover;
+  }
+}
+@media screen and (min-width: 1200px) {
+  .max-override.homepage-brick.link.split-background>.foreground> :first-child {
+    background: url('homepage/assets/maxlinkpod-images/media_18ae9f841e7d0785e5080f0dd2bc7b27702320799.jpeg') no-repeat center center / cover;
+  }
+}
 
 .homepage-brick.news hr {
   margin: var(--spacing-xs) 0;

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
@@ -67,12 +67,14 @@ function enforceHeaderLevel(node, level) {
 }
 
 export default async function init(el) {
-  console.log('mwpw-158064 is running!');
   el.classList.forEach((className) => {
     if (className.includes('-grid')) {
       el.closest('.fragment')?.parentNode.classList.add(className);
     }
   });
+  if (el.classList.contains('link')) {
+    el.classList.add('max-override');
+  }
 
   const linkParentNode = el.querySelector('a').parentNode;
   const linkParentNodeName = linkParentNode.nodeName === 'CHECKOUT-LINK' ? linkParentNode.parentNode.nodeName : linkParentNode.nodeName;

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
@@ -72,9 +72,6 @@ export default async function init(el) {
       el.closest('.fragment')?.parentNode.classList.add(className);
     }
   });
-  if (el.classList.contains('link')) {
-    el.classList.add('max-override');
-  }
 
   const linkParentNode = el.querySelector('a').parentNode;
   const linkParentNodeName = linkParentNode.nodeName === 'CHECKOUT-LINK' ? linkParentNode.parentNode.nodeName : linkParentNode.nodeName;

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
@@ -67,7 +67,7 @@ function enforceHeaderLevel(node, level) {
 }
 
 export default async function init(el) {
-  console.log('mwpw-158064 is running');
+  console.log('mwpw-158064 is running!');
   el.classList.forEach((className) => {
     if (className.includes('-grid')) {
       el.closest('.fragment')?.parentNode.classList.add(className);

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
@@ -1,0 +1,192 @@
+import { getLibs } from '../../scripts/utils.js';
+
+// size: [heading, body, ...detail]
+// blockTypeSizes array order: heading, body, detail, button, link
+const blockTypeSizes = {
+  small: ['m', 's', 's', 'l', 's'],
+  medium: ['l', 'm', 'm', 'l', 'm'],
+  large: ['xl', 'm', 'l', 'l', 'm'],
+  xlarge: ['xxl', 'l', 'xl', 'l', 'l'],
+  'link': ['m', 'xs', 'm', 's', 'xs'],
+  'news': ['xs', 's', 'm', 's', 'xs'],
+  'above-pods': ['xxl', 'm', 'l', 'xl', 'm'],
+  'full-desktop': ['xl', 'l', 'm', 'l', 'm'],
+  default: ['m', 'm', 'l', 'l', 'xs'],
+};
+
+function getBlockSize(el) {
+  const sizes = Object.keys(blockTypeSizes);
+  return sizes.find((size) => el.classList.contains(size)) || sizes[8];
+}
+
+function decorateBlockBg(node) {
+  node.classList.add('background');
+  if (!node.querySelector('img')) {
+    node.style.background = node.textContent.trim();
+    [...node.children].forEach((e) => {
+      e.remove();
+    });
+  } else {
+    node.classList.add('background');
+    if (node.childElementCount > 1) {
+      const viewports = ['mobileOnly', 'tabletOnly', 'desktopOnly'];
+      if (node.childElementCount === 2) {
+        node.children[0].classList.add(viewports[0], viewports[1]);
+        node.children[1].classList.add(viewports[2]);
+      } else {
+        [...node.children].forEach((e, i) => {
+          e.classList.add(viewports[i]);
+        });
+      }
+    }
+
+    [...node.children].forEach((e) => {
+      const image = e.querySelector('img');
+      if (image) {
+        const text = e.textContent.trim();
+        if (text !== '') {
+          //const points = text?.slice(text.indexOf(':') + 1).split(',');
+          const [x, y = '', s = ''] = text.split(',');
+          image.style.objectPosition = `${x.trim().toLowerCase()} ${y.trim().toLowerCase()}`;
+          if (s !== '') image.style.objectFit = s.trim().toLowerCase();
+          const picture = e.querySelector('picture');
+          e.innerHTML = picture.outerHTML;
+        }
+      }
+    });
+  }
+}
+
+function enforceHeaderLevel(node, level) {
+  const clone = document.createElement(`H${level}`);
+  for (const attr of node.attributes) {
+    clone.setAttribute(attr.name, attr.value);
+  }
+  clone.innerHTML = node.innerHTML;
+  node.replaceWith(clone);
+}
+
+export default async function init(el) {
+  console.log('mwpw-158064 is running');
+  el.classList.forEach((className) => {
+    if (className.includes('-grid')) {
+      el.closest('.fragment')?.parentNode.classList.add(className);
+    }
+  });
+
+  const linkParentNode = el.querySelector('a').parentNode;
+  const linkParentNodeName = linkParentNode.nodeName === 'CHECKOUT-LINK' ? linkParentNode.parentNode.nodeName : linkParentNode.nodeName;
+  const miloLibs = getLibs();
+  const { decorateButtons, decorateBlockText } = await import(`${miloLibs}/utils/decorate.js`);
+  const { createTag } = await import(`${miloLibs}/utils/utils.js`);
+  const blockSize = getBlockSize(el);
+
+  decorateButtons(el, `button-${blockTypeSizes[blockSize][3]}`);
+  let rows = el.querySelectorAll(':scope > div');
+  const headers = el.querySelectorAll('h1, h2, h3, h4, h5, h6, .highlight-row > *');
+
+  if (el.classList.contains('link')) {
+    const background = createTag('div', { class: 'background first-background' }, false);
+    el.prepend(background);
+    if (rows.length === 2) {
+      const [left, right] = rows;
+      const rightColumn = right.querySelector(':scope > div');
+      left.appendChild(rightColumn);
+      right.remove();
+    }
+    if (!el.classList.contains('split-background')) {
+      const highlight = createTag('div', { class: 'highlight-row' }, false);
+      el.prepend(highlight);
+    } 
+  } else if (el.classList.contains('news') && rows.length > 1) {
+    const [highlight, ...tail] = rows;
+    highlight.classList.add('highlight-row');
+    el.querySelectorAll('a').forEach((a) => a.classList.add('body-xs'));
+    rows = tail;
+  } else if (el.classList.contains('above-pods')) {
+    headers.forEach((header) => enforceHeaderLevel(header, 1));
+    el.querySelectorAll('a.con-button').forEach((button) => button.classList.add('button-justified-mobile'));
+  } else {
+    if (rows.length > 1) {
+      let [head, ...tail] = rows;
+      decorateBlockBg(head);
+      head.classList.add('first-background');
+      rows = tail;
+      if (rows.length > 1) {
+        [head, ...tail] = rows;
+        decorateBlockBg(head);
+        rows = tail;
+      }
+      const links = el.querySelectorAll('a');
+      if (links.length === 1) {
+        el.classList.add('click');
+      } else {
+        el.classList.add('multi-link');
+        const actionAreaSize = el.classList.contains('static-links') ? 'body-m': 'body-xs';
+        links.forEach((a) => a.parentNode.className = `action-area ${actionAreaSize}`);
+        if (el.classList.contains('icon-in-header')) {
+          const header = el.querySelector('h1, h2, h3, h4, h5, h6');
+          const icon = el.querySelector('picture');
+          if (header && icon) {
+            header.prepend(icon);
+          }
+        }
+      }
+    }
+  }
+
+  if (!el.classList.contains('above-pods')) {
+    headers.forEach((header, counter) => {
+      if (!counter) {
+        enforceHeaderLevel(header, 3);
+      } else {
+        enforceHeaderLevel(header, 4);
+      }
+    });
+  }
+  const config = blockTypeSizes[blockSize];
+  const overrides = ['-heading', '-body', '-detail'];
+  overrides.forEach((override, index) => {
+    const hasClass = [...el.classList].filter((listItem) => listItem.includes(override));
+    if (hasClass.length) config[index] = hasClass[0].split('-').shift().toLowerCase();
+  });
+  decorateBlockText(el, config);
+  rows.forEach((row) => { row.classList.add('foreground'); });
+
+  if (el.classList.contains('click')) {
+    const { decorateDefaultLinkAnalytics } = await import(`${miloLibs}/martech/attributes.js`);
+    await decorateDefaultLinkAnalytics(el);
+    const link = el.querySelector('a');
+    const foreground = el.querySelector('.foreground');
+    if (link && foreground) {
+      let href = link.href;
+      let modalLink = false;
+      if (link.dataset.modalPath && link.dataset.modalHash) {
+        modalLink = true;
+        href = `${window.location.origin}${link.dataset.modalPath}${link.dataset.modalHash}`;
+      }
+      const attributes = {
+        class: 'foreground',
+        href: href,
+        'daa-ll': link.getAttribute('daa-ll')
+      };
+      if (link.hasAttribute('target')) attributes.target = link.getAttribute('target')
+      
+      const divLinkClass = linkParentNodeName === 'P' ? 'click-link body-xs' : link.className;
+      const divLink = createTag('div', { class: divLinkClass }, link.innerText);
+      link.insertAdjacentElement('beforebegin', divLink);
+      foreground.insertAdjacentElement('beforebegin', link);
+      link.innerHTML = '';
+      link.classList.add('foreground');
+      link.classList.remove('con-button', 'button-l', 'blue');
+      link.append(...foreground.childNodes);
+      foreground.remove();
+    }
+  }
+
+  const detail = el.querySelector('p[class*="detail"]');
+  if (detail) {
+    const icon = detail.querySelector('img');
+    if (icon) detail.classList.add('icon-detail');
+  }
+}

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
@@ -1,4 +1,4 @@
-import { getLibs } from '../../scripts/utils.js';
+import { getLibs } from '../../../utils.js';
 
 // size: [heading, body, ...detail]
 // blockTypeSizes array order: heading, body, detail, button, link


### PR DESCRIPTION
Adds a temporary fix to enable using MEP to update background image for homepage linkpod for Max

![Screenshot 2024-09-10 at 10 00 30 AM](https://github.com/user-attachments/assets/a42c570e-7f2e-407d-9613-493edf564a6a)

Steps to QA:
- navigate to this url: https://maxlinkpod--homepage--adobecom.hlx.page/homepage/fragments/loggedout/personalization/pages/hp-10-14-24-max-mweb?mep=%2Fhomepage%2Ffragments%2Fmep%2Fhp-10-14-max.json--all
- confirm that link pod now has the background image shown in the screenshot above, rather than the original linear gradient background

Resolves: [MWPW-158064](https://jira.corp.adobe.com/browse/MWPW-158064)

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
- After: https://maxlinkpod--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
