### PR TITLE
MWPW-158064 [MEP]Homepage Linkpod for MAX

### DIFF
--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
@@ -396,6 +396,7 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   background: linear-gradient(90deg, rgba(33,99,212,1) 0%, rgba(93,227,116,1) 100%);
 }
 
+.homepage-brick.above-pods .foreground p.detail-xl:first-child,
 .homepage-brick.click .foreground p.detail-xl:first-child,
 .homepage-brick.news .highlight-row>div:first-child {
   font-size: var(--type-heading-s-size);

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
@@ -368,7 +368,7 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   padding: var(--spacing-m) var(--spacing-s) var(--spacing-s);
 }
 .homepage-brick.link.split-background>.foreground> :first-child {
-  background: url('/homepage/assets/maxlinkpod-images/media_1e22ca66b9126e059d314c41481e81d4e1f4fe2b9.png') no-repeat center center / cover;
+  background: url('/homepage/assets/maxlinkpod-images/media_1a9749c58923ba2eb15f1fddf4df09ed74cdfe26e.png') no-repeat center center / cover;
 }
 
 @media screen and (min-width: 600px) {

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
@@ -368,17 +368,17 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   padding: var(--spacing-m) var(--spacing-s) var(--spacing-s);
 }
 .homepage-brick.link.split-background>.foreground> :first-child {
-  background: url('/homepage/assets/maxlinkpod-images/media_1d1d79f99a64f4a6e066253565ebf07c8a0f6bf07.jpeg') no-repeat center center / cover;
+  background: url('/homepage/assets/maxlinkpod-images/media_1e22ca66b9126e059d314c41481e81d4e1f4fe2b9.png') no-repeat center center / cover;
 }
 
 @media screen and (min-width: 600px) {
   .homepage-brick.link.split-background>.foreground> :first-child {
-    background: url('/homepage/assets/maxlinkpod-images/media_12290414600700935f22f3592af86e6daeb13dc10.jpeg') no-repeat center center / cover;
+    background: url('/homepage/assets/maxlinkpod-images/media_1a9749c58923ba2eb15f1fddf4df09ed74cdfe26e.png') no-repeat center center / cover;
   }
 }
 @media screen and (min-width: 1200px) {
   .homepage-brick.link.split-background>.foreground> :first-child {
-    background: url('/homepage/assets/maxlinkpod-images/media_18ae9f841e7d0785e5080f0dd2bc7b27702320799.jpeg') no-repeat center center / cover;
+    background: url('/homepage/assets/maxlinkpod-images/media_14e4e554c611ac52305e259e913a794b2f92b2157.png') no-repeat center center / cover;
   }
 }
 

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
@@ -317,6 +317,11 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   font-size: var(--type-detail-l-size);
   line-height: var(--type-detail-l-lh);
 }
+.homepage-brick.click .foreground p.detail-xl:first-child {
+  font-size: var(--type-heading-s-size);
+  line-height: var(--type-heading-s-lh);
+  text-transform: none;
+}
 
 .homepage-brick.above-pods {
   padding: var(--spacing-l);

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
@@ -368,7 +368,7 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   padding: var(--spacing-m) var(--spacing-s) var(--spacing-s);
 }
 .homepage-brick.link.split-background>.foreground> :first-child {
-  background: url('/homepage/assets/maxlinkpod-images/media_1a9749c58923ba2eb15f1fddf4df09ed74cdfe26e.png') no-repeat center center / cover;
+  background: url('/homepage/assets/maxlinkpod-images/media_1e22ca66b9126e059d314c41481e81d4e1f4fe2b9.png') no-repeat center center / cover;
 }
 
 @media screen and (min-width: 600px) {

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
@@ -317,11 +317,6 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   font-size: var(--type-detail-l-size);
   line-height: var(--type-detail-l-lh);
 }
-.homepage-brick.click .foreground p.detail-xl:first-child {
-  font-size: var(--type-heading-s-size);
-  line-height: var(--type-heading-s-lh);
-  text-transform: none;
-}
 
 .homepage-brick.above-pods {
   padding: var(--spacing-l);
@@ -399,6 +394,13 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
 .homepage-brick.news .highlight-row {
   color: #FFF;
   background: linear-gradient(90deg, rgba(33,99,212,1) 0%, rgba(93,227,116,1) 100%);
+}
+
+.homepage-brick.click .foreground p.detail-xl:first-child,
+.homepage-brick.news .highlight-row>div:first-child {
+  font-size: var(--type-heading-s-size);
+  line-height: var(--type-heading-s-lh);
+  text-transform: none;
 }
 
 .homepage-brick .positioned-background {

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
@@ -368,17 +368,17 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   padding: var(--spacing-m) var(--spacing-s) var(--spacing-s);
 }
 .homepage-brick.link.split-background>.foreground> :first-child {
-  background: url('/homepage/assets/maxlinkpod-images/media_1e22ca66b9126e059d314c41481e81d4e1f4fe2b9.png') no-repeat center center / cover;
+  background: url('/homepage/assets/maxlinkpod-images/media_1e22ca66b9126e059d314c41481e81d4e1f4fe2b9.png') no-repeat center top / cover;
 }
 
 @media screen and (min-width: 600px) {
   .homepage-brick.link.split-background>.foreground> :first-child {
-    background: url('/homepage/assets/maxlinkpod-images/media_1a9749c58923ba2eb15f1fddf4df09ed74cdfe26e.png') no-repeat center center / cover;
+    background: url('/homepage/assets/maxlinkpod-images/media_1a9749c58923ba2eb15f1fddf4df09ed74cdfe26e.png') no-repeat center top / cover;
   }
 }
 @media screen and (min-width: 1200px) {
   .homepage-brick.link.split-background>.foreground> :first-child {
-    background: url('/homepage/assets/maxlinkpod-images/media_14e4e554c611ac52305e259e913a794b2f92b2157.png') no-repeat center center / cover;
+    background: url('/homepage/assets/maxlinkpod-images/media_14e4e554c611ac52305e259e913a794b2f92b2157.png') no-repeat center top / cover;
   }
 }
 

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.css
@@ -373,17 +373,22 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
   padding: var(--spacing-m) var(--spacing-s) var(--spacing-s);
 }
 .homepage-brick.link.split-background>.foreground> :first-child {
-  background: url('/homepage/assets/maxlinkpod-images/media_1e22ca66b9126e059d314c41481e81d4e1f4fe2b9.png') no-repeat center top / cover;
+  background: url('/homepage/assets/maxlinkpod-images/media_1e22ca66b9126e059d314c41481e81d4e1f4fe2b9.png') no-repeat right top / cover;
+  min-height: 184px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
 @media screen and (min-width: 600px) {
   .homepage-brick.link.split-background>.foreground> :first-child {
-    background: url('/homepage/assets/maxlinkpod-images/media_1a9749c58923ba2eb15f1fddf4df09ed74cdfe26e.png') no-repeat center top / cover;
+    background: url('/homepage/assets/maxlinkpod-images/media_1a9749c58923ba2eb15f1fddf4df09ed74cdfe26e.png') no-repeat right top / cover;
   }
 }
 @media screen and (min-width: 1200px) {
   .homepage-brick.link.split-background>.foreground> :first-child {
-    background: url('/homepage/assets/maxlinkpod-images/media_14e4e554c611ac52305e259e913a794b2f92b2157.png') no-repeat center top / cover;
+    background: url('/homepage/assets/maxlinkpod-images/media_14e4e554c611ac52305e259e913a794b2f92b2157.png') no-repeat right top / cover;
+    min-height: 200px;
   }
 }
 

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
@@ -9,7 +9,7 @@ const blockTypeSizes = {
   xlarge: ['xxl', 'l', 'xl', 'l', 'l'],
   'link': ['m', 'xs', 'm', 's', 'xs'],
   'news': ['xs', 's', 'm', 's', 'xs'],
-  'above-pods': ['xxl', 'm', 'l', 'xl', 'm'],
+  'above-pods': ['xxl', 'm', 'xl', 'xl', 'm'],
   'full-desktop': ['xl', 'l', 'm', 'l', 'm'],
   default: ['m', 'm', 'xl', 'l', 'xs'],
 };

--- a/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
+++ b/homepage/scripts/mep/mwpw-158064/homepage-brick/homepage-brick.js
@@ -11,7 +11,7 @@ const blockTypeSizes = {
   'news': ['xs', 's', 'm', 's', 'xs'],
   'above-pods': ['xxl', 'm', 'l', 'xl', 'm'],
   'full-desktop': ['xl', 'l', 'm', 'l', 'm'],
-  default: ['m', 'm', 'l', 'l', 'xs'],
+  default: ['m', 'm', 'xl', 'l', 'xs'],
 };
 
 function getBlockSize(el) {


### PR DESCRIPTION
To address additional requirements added to the ticket, this updates MAX linkpod background override images and linkpod eyebrow size. 
Steps to QA: check that eyebrow text in these four linkpods below, and the "In the news" pod all have font-size set to var(--type-heading-s-size) and line-height set to var(--type-heading-s-lh). 
![Screenshot 2024-09-12 at 2 40 46 PM](https://github.com/user-attachments/assets/de137016-1863-45f9-9425-416785ea1886)

The Adobe MAX 2024 linkpod background should max this image:
![Screenshot 2024-09-12 at 2 47 02 PM](https://github.com/user-attachments/assets/d24e6938-22fc-473b-87b3-23a11b1ca5af)

Resolves: [MWPW-158064](https://jira.corp.adobe.com/browse/MWPW-158064)

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.page/homepage/fragments/loggedout/personalization/pages/hp-10-14-24-max-mweb?mep=%2Fhomepage%2Ffragments%2Fmep%2Fhp-10-14-max.json--all&martech=off
- After: https://maxlinkpodnewimages--homepage--adobecom.hlx.page/homepage/fragments/loggedout/personalization/pages/hp-10-14-24-max-mweb?mep=%2Fhomepage%2Ffragments%2Fmep%2Fhp-10-14-max.json--all&martech=off
