### PR TITLE
[MWPW-158447] Added stage domains map

### DIFF
--- a/homepage/scripts/scripts.js
+++ b/homepage/scripts/scripts.js
@@ -129,14 +129,15 @@ const locales = {
 };
 
 const stageDomainsMap = {
-  'www.adobe.com': 'www.stage.adobe.com',
-  'business.adobe.com': 'business.stage.adobe.com',
-  'learning.adobe.com': 'learning.stage.adobe.com',
-  'helpx.adobe.com': 'helpx.stage.adobe.com',
-  'status.adobe.com': 'status.stage.adobe.com',
-  'news.adobe.com': 'news.stage.adobe.com',
-  'blog.adobe.com': 'blog.stage.adobe.com',
-  'developer.adobe.com': 'developer-stage.adobe.com',
+  'www.stage.adobe.com': {
+    'www.adobe.com': 'origin',
+  },
+  '--homepage--adobecom.hlx.live': {
+    'www.adobe.com': 'origin',
+  },
+  '--homepage--adobecom.hlx.page': {
+    'www.adobe.com': 'origin',
+  },
 };
 
 // Add any config options.


### PR DESCRIPTION
This PR adds the stageDomainsMap, enabling the conversion of production URLs to their stage equivalents in the stage environment.
More details about this feature can be found in [this discussion](https://github.com/orgs/adobecom/discussions/2880).

Resolves: [MWPW-158447](https://jira.corp.adobe.com/browse/MWPW-158447)

**Test URLs:**

Before: https://main--homepage--adobecom.hlx.page/?martech=off
After: https://mwpw-158447-domains-map--homepage--adobecom.hlx.page/?martech=off