### PR TITLE
Suggested Bug Fix for home-page brick top padding issue and updated news SEO background

### DIFF
--- a/homepage/blocks/homepage-brick/homepage-brick.css
+++ b/homepage/blocks/homepage-brick/homepage-brick.css
@@ -202,7 +202,7 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
 }
 
 .homepage-brick p,
-.homepage-brick [class^="body-"] { margin: var(--spacing-xxs) 0; }
+.homepage-brick [class^="body-"] { margin: 0 0 var(--spacing-xxs) 0; }
 
 .homepage-brick [class^="heading"] { margin: 0 0 var(--spacing-xxs) 0; }
 .homepage-brick.link [class^="heading"]:not(:first-child) { margin-top: var(--spacing-xs); }
@@ -374,7 +374,7 @@ body:not([data-mep-highlight="true"]) .section.masonry [data-removed-manifest-id
 
 .homepage-brick.news .highlight-row {
   color: #FFF;
-  background: linear-gradient(90deg, rgba(33,99,212,1) 0%, rgba(93,227,116,1) 100%);
+  background: #262530;
 }
 
 .homepage-brick .positioned-background {


### PR DESCRIPTION
- This PR fixes a bug that added a gray space at the top of the homepage-brick, and pushed text down further than intended
- It also updates the homepage-brick.news background color to #262530 for accessibility compliance.

Resolves: [MWPW-162769](https://jira.corp.adobe.com/browse/MWPW-162769)

![Screenshot 2024-11-19 at 2 37 45 PM](https://github.com/user-attachments/assets/de772a29-ce3f-41a8-873b-46570b052bc0)
![Screenshot 2024-11-19 at 3 07 38 PM](https://github.com/user-attachments/assets/8f23f288-53bd-41a4-bde8-43d5469aaf85)

![Screenshot 2024-11-19 at 3 05 33 PM](https://github.com/user-attachments/assets/0256e26f-ff5e-4bf3-b502-ad869922f01d)
![Screenshot 2024-11-19 at 3 05 12 PM](https://github.com/user-attachments/assets/d26d371f-c236-42e7-bb5e-f598be65ff79)


Steps to QA:

1. See the Before and After links below to confirm that spacing issue is resolved for the Creative Cloud pod. 
2. For the SEO background color update to the news brick, please refer to the US homepage:  https://podtopborderfix--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
The "In the news" pod background should be a solid #262530 rather than a linear-gradient;


**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.live/es/homepage/index-loggedout?martech=off
- After: https://podtopborderfix--homepage--adobecom.hlx.live/es/homepage/index-loggedout?martech=off
