### PR TITLE
Migrate Homepage to Helix 5

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -7,5 +7,5 @@
 Resolves: [MWPW-NUMBER](https://jira.corp.adobe.com/browse/MWPW-NUMBER)
 
 **Test URLs:**
-- Before: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
-- After: https://<branch>--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
+- Before: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off
+- After: https://<branch>--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Developing
 1. Install the [Helix CLI](https://github.com/adobe/helix-cli): `sudo npm install -g @adobe/helix-cli`
-1. Run `hlx up` this repo's folder. (opens your browser at `http://localhost:3000`)
+1. Run `aem up` this repo's folder. (opens your browser at `http://localhost:3000`)
 1. Open this repo's folder in your favorite editor and start coding.
 
 ## Testing

--- a/homepage/scripts/utils.js
+++ b/homepage/scripts/utils.js
@@ -20,16 +20,16 @@ export const [setLibs, getLibs] = (() => {
       libs = (() => {
         const { hostname, search } = location || window.location;
         if (hostname.includes('stage.adobe.com')) {
-          return "https://stage--milo--adobecom.hlx.live/libs";
+          return "https://stage--milo--adobecom.aem.live/libs";
         }
-        if (!['.hlx.', 'local'].some((i) => hostname.includes(i))) return prodLibs;
+        if (!['.hlx.', '.aem.', 'local'].some((i) => hostname.includes(i))) return prodLibs;
         const branch = new URLSearchParams(search).get('milolibs') || 'main';
         // Validate the branch name to mitigate potential security risks
         if (!/^[a-zA-Z0-9-_]+$/.test(branch)) {
           throw new Error("Invalid branch name.");
         }
         if (branch === 'local') return 'http://localhost:6456/libs';
-        return branch.includes('--') ? `https://${branch}.hlx.live/libs` : `https://${branch}--milo--adobecom.hlx.live/libs`;
+        return branch.includes('--') ? `https://${branch}.aem.live/libs` : `https://${branch}--milo--adobecom.aem.live/libs`;
       })();
       return libs;
     }, () => libs,

--- a/test/scripts/utils.test.js
+++ b/test/scripts/utils.test.js
@@ -4,7 +4,7 @@ import { setLibs } from '../../scripts/utils.js';
 describe('Libs', () => {
   it('Default Libs', () => {
     const libs = setLibs('/libs');
-    expect(libs).to.equal('https://main--milo--adobecom.hlx.live/libs');
+    expect(libs).to.equal('https://main--milo--adobecom.aem.live/libs');
   });
 
   it('Does not support milolibs query param on prod', () => {
@@ -22,7 +22,7 @@ describe('Libs', () => {
       search: '?milolibs=foo',
     };
     const libs = setLibs('/libs', location);
-    expect(libs).to.equal('https://foo--milo--adobecom.hlx.live/libs');
+    expect(libs).to.equal('https://foo--milo--adobecom.aem.live/libs');
   });
 
   it('Supports local milolibs query param', () => {
@@ -40,6 +40,6 @@ describe('Libs', () => {
       search: '?milolibs=awesome--milo--forkedowner',
     };
     const libs = setLibs('/libs', location);
-    expect(libs).to.equal('https://awesome--milo--forkedowner.hlx.live/libs');
+    expect(libs).to.equal('https://awesome--milo--forkedowner.aem.live/libs');
   });
 });

--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,6 +1,8 @@
 {
   "project": "HOMEPAGE",
   "host": "www.adobe.com",
+  "previewHost": "main--homepage--adobecom.aem.page",
+  "liveHost": "main--homepage--adobecom.aem.live",
   "plugins": [
     {
       "id": "path",
@@ -39,7 +41,7 @@
       "environments": [
         "edit"
       ],
-      "url": "https://main--milo--adobecom.hlx.page/tools/loc/index.html?project=homepage--adobecom",
+      "url": "https://main--milo--adobecom.aem.page/tools/loc/index.html?project=homepage--adobecom",
       "passReferrer": true,
       "passConfig": true,
       "excludePaths": [ "/**" ],
@@ -50,7 +52,7 @@
       "id": "localize-2",
       "title": "Localize (V2)",
       "environments": [ "edit" ],
-      "url": "https://main--homepage--adobecom.hlx.page/tools/loc?milolibs=locui",
+      "url": "https://main--homepage--adobecom.aem.page/tools/loc?milolibs=locui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]
@@ -60,7 +62,7 @@
       "id": "floodgate",
       "title": "Floodgate",
       "environments": [ "edit" ],
-      "url": "https://main--homepage--adobecom.hlx.page/tools/floodgate?milolibs=floodgateui",
+      "url": "https://main--homepage--adobecom.aem.page/tools/floodgate?milolibs=floodgateui",
       "passReferrer": true,
       "passConfig": true,
       "includePaths": [ "**.xlsx**" ]


### PR DESCRIPTION
### Description 
Upgrading to `.aem.` from `.hlx.` as per the product requirements and [docs](https://www.aem.live/developer/upgrade).
This is not meant to be a complete PR, just one that starts you off. This should be carefully tested.

### Todo
1. QA, QA, QA
2. Merge
3. Swap origin on the akamai level to consume `aem.page` and `aem.live` 
4. Once origins are switched, remove any references to `hlx.live` or `hlx.page` from the codebase

### Test URLs
All variations should continue working: `(hlx|aem).(page|live)`

Before: https://main--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off
After: https://hlx5--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off

Before: https://main--homepage--adobecom.aem.page/homepage/index-loggedout?martech=off (not working, code from this branch is needed)
After: https://hlx5--homepage--adobecom.hlx.page/homepage/index-loggedout?martech=off

Before: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
After: https://hlx5--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off

Before: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off (not working, code from this branch is needed)
After: https://hlx5--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
