### PR TITLE
Update preview/live hosts with .hlx. until authorization issues are solved

### DIFF
--- a/tools/sidekick/config.json
+++ b/tools/sidekick/config.json
@@ -1,8 +1,8 @@
 {
   "project": "HOMEPAGE",
   "host": "www.adobe.com",
-  "previewHost": "main--homepage--adobecom.aem.page",
-  "liveHost": "main--homepage--adobecom.aem.live",
+  "previewHost": "main--homepage--adobecom.hlx.page",
+  "liveHost": "main--homepage--adobecom.hlx.live",
   "plugins": [
     {
       "id": "path",


### PR DESCRIPTION
It seems that https://github.com/adobecom/homepage/pull/140 hasn't been properly tested before being merged and authorization issues are blocking authors from performing their tasks. This PR reverts the preview and live hosts for the time being, until Authorization issues are further investigated.

**Test URLs:**
- Before: https://main--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
- After: https://revert-to-hlx--homepage--adobecom.hlx.live/homepage/index-loggedout?martech=off
