### PR TITLE
MWPW-167631: adding blog.adobe.com to prodDomains

### DIFF
--- a/homepage/scripts/scripts.js
+++ b/homepage/scripts/scripts.js
@@ -152,7 +152,7 @@ const CONFIG = {
   codeRoot: '/homepage',
   contentRoot: '/homepage',
   imsClientId: 'homepage_milo',
-  prodDomains: ['stock.adobe.com', 'helpx.adobe.com', 'business.adobe.com', 'www.adobe.com'],
+  prodDomains: ['stock.adobe.com', 'helpx.adobe.com', 'business.adobe.com', 'www.adobe.com', 'blog.adobe.com'],
   stageDomainsMap,
   geoRouting: 'on',
   fallbackRouting: 'on',


### PR DESCRIPTION
Resolves: [MWPW-167631](https://jira.corp.adobe.com/browse/MWPW-167631)

**Test URLs:**
- Before: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off
- After: https://MWPW-167631--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off
