### PR TITLE
MWPW-173197: graybox env mapped to stage

### DIFF
--- a/homepage/scripts/scripts.js
+++ b/homepage/scripts/scripts.js
@@ -141,8 +141,8 @@ const stageDomainsMap = {
     'creativecloud.adobe.com': 'stage.creativecloud.adobe.com',
     'projectneo.adobe.com': 'stg.projectneo.adobe.com',
   },
-  '.graybox.adobe.com': { 'www.adobe.com': 'origin' },
-  '.business-graybox.adobe.com': { 'business.adobe.com': 'origin' },
+  '.graybox.adobe.com': { 'www.stage.adobe.com': 'origin' },
+  '.business-graybox.adobe.com': { 'business.stage.adobe.com': 'origin' },
 };
 
 // Add any config options.


### PR DESCRIPTION
* CORS issue is seen when loading fragments on graybox
* Akamai has changed the settings on stage
* _stageDomainsMap_ updated to point to stage
* Unfortunately, this fix can only be validated after merged to stage

Resolves: [MWPW-173197](https://jira.corp.adobe.com/browse/MWPW-173197)

**Test URLs:**
- Before: https://main--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off
- After: https://gb-env--homepage--adobecom.aem.live/homepage/index-loggedout?martech=off
